### PR TITLE
Sdk docs work

### DIFF
--- a/src/martian_apart_hack_sdk/backend_clients/judges.py
+++ b/src/martian_apart_hack_sdk/backend_clients/judges.py
@@ -120,6 +120,14 @@ class JudgesClient:
         return self._init_judge(resp.json())
 
     def get_versions(self, judge_id: str) -> List[judge_resource.Judge]:
+        """Get all versions of a judge.
+        
+        Args:
+            judge_id (str): The ID of the judge to get versions for.
+
+        Returns:
+            A list of all versions of the judge.
+        """
         resp = self.httpx.get(f"/judges/{judge_id}/versions")
         resp.raise_for_status()
         if not resp.json()["judges"]:
@@ -130,12 +138,22 @@ class JudgesClient:
         completion_request: Dict[str, Any],
         completion_response: chat_completion.ChatCompletion,
     ) -> str:
-        """
-        This method render judging prompt. It works only for rubric judge
-        :param judge:
-        :param completion_request:
-        :param completion_response:
-        :return: str: rendered prompt
+        """Render the judging prompt for a judge.
+
+        Concatenates the judge's prescript, rubric, and postscript;
+        evaluates variables in the prompt (e.g. `${min_score}`, `${max_score}`, `${content}`);
+        and returns the rendered prompt. 
+        
+        This is useful for debugging or for getting a sense of what the judge will see,
+        without having to run the judge or call the API.
+        
+        Args:
+            judge (judge_resource.Judge): The judge to render the prompt for.
+            completion_request (Dict[str, Any]): The completion request parameters.
+            completion_response (chat_completion.ChatCompletion): The completion response.
+
+        Returns:
+            str: The rendered prompt.
         """
         payload = self._prepare_judge_evaluation_payload(judge, completion_request, completion_response)
         resp = self.httpx.post(

--- a/src/martian_apart_hack_sdk/backend_clients/judges.py
+++ b/src/martian_apart_hack_sdk/backend_clients/judges.py
@@ -62,6 +62,7 @@ class JudgesClient:
         Raises:
             ResourceAlreadyExistsError: If a judge with the given ID already exists.
             httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out.
         """
 
         if self._is_judge_exists(judge_id):
@@ -95,6 +96,7 @@ class JudgesClient:
         Raises:
             ResourceNotFoundError: If the judge with the given ID does not exist.
             httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out.
         """
         payload = self._get_judge_spec_payload(judge_spec.to_dict())
         # can't update labels/description in API
@@ -110,6 +112,7 @@ class JudgesClient:
 
         Raises:
             httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out.
         """
         resp = self.httpx.get("/judges")
         resp.raise_for_status()
@@ -127,6 +130,7 @@ class JudgesClient:
 
         Raises:
             httpx.HTTPError: If the request fails for reasons other than a missing judge.
+            httpx.TimeoutException: If the request times out.
         """
         params = dict(version=version) if version else None
         resp = self.httpx.get(f"/judges/{judge_id}", params=params)
@@ -150,6 +154,7 @@ class JudgesClient:
         Raises:
             ResourceNotFoundError: If the judge with the given ID does not exist.
             httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out.
         """
         resp = self.httpx.get(f"/judges/{judge_id}/versions")
         resp.raise_for_status()

--- a/src/martian_apart_hack_sdk/backend_clients/judges.py
+++ b/src/martian_apart_hack_sdk/backend_clients/judges.py
@@ -55,6 +55,13 @@ class JudgesClient:
             judge_id (str): An arbitrary identifier (chosen by you) for the judge. You'll need to use this identifier to reference the judge in other API calls.
             judge_spec (Union[judge_specs.JudgeSpec, Dict[str, Any]]): The specification for the judge.
             description (Optional[str], optional): The description of the judge, for your own reference.
+
+        Returns:
+            judge_resource.Judge: The newly created judge resource.
+
+        Raises:
+            ResourceAlreadyExistsError: If a judge with the given ID already exists.
+            httpx.HTTPError: If the request fails.
         """
 
         if self._is_judge_exists(judge_id):
@@ -79,10 +86,15 @@ class JudgesClient:
             judge_spec (judge_specs.JudgeSpec): The new specification for the judge.
 
         Returns:
-            The new version of the judge.
+            judge_resource.Judge: The new version of the judge. 
+            
+            Judge updates are non-destructive. The updated judge will have an incremented version number. 
+            You can use this version number to reference the judge in other API calls. 
+            You can also access previous versions of the judge by passing the previous version number to the `get` method.
 
-            Note: Judge updates are non-destructive. The updated judge will have an incremented version number. You can use this version number to reference the judge in other API calls.
-            You can also access previous versions of the judge by passing the previous verison number to the `get` method.
+        Raises:
+            ResourceNotFoundError: If the judge with the given ID does not exist.
+            httpx.HTTPError: If the request fails.
         """
         payload = self._get_judge_spec_payload(judge_spec.to_dict())
         # can't update labels/description in API
@@ -91,17 +103,20 @@ class JudgesClient:
         return self._init_judge(json_data=resp.json())
 
     def list(self) -> list[judge_resource.Judge]:
-        """List all judges.
+        """List all judges in your organization.
         
         Returns:
-            A list of all judges.
+            list[judge_resource.Judge]: A list of all judges.
+
+        Raises:
+            httpx.HTTPError: If the request fails.
         """
         resp = self.httpx.get("/judges")
         resp.raise_for_status()
         return [self._init_judge(j) for j in resp.json()["judges"]]
 
     def get(self, judge_id: str, version=None) -> Optional[judge_resource.Judge]:
-        """Get a judge.
+        """Get a specific judge by ID and optionally version.
         
         Args:
             judge_id (str): The ID of the judge to get.
@@ -110,7 +125,8 @@ class JudgesClient:
         Returns:
             judge_resource.Judge: The judge resource. OR None if the judge does not exist.
 
-        
+        Raises:
+            httpx.HTTPError: If the request fails for reasons other than a missing judge.
         """
         params = dict(version=version) if version else None
         resp = self.httpx.get(f"/judges/{judge_id}", params=params)
@@ -120,13 +136,20 @@ class JudgesClient:
         return self._init_judge(resp.json())
 
     def get_versions(self, judge_id: str) -> List[judge_resource.Judge]:
-        """Get all versions of a judge.
+        """Get all versions of a specific judge.
+        
+        Each time a judge is updated, a new version is created. This method returns all versions
+        of a judge, ordered from newest to oldest.
         
         Args:
             judge_id (str): The ID of the judge to get versions for.
 
         Returns:
-            A list of all versions of the judge.
+            List[judge_resource.Judge]: A list of all versions of the judge, ordered from newest to oldest.
+
+        Raises:
+            ResourceNotFoundError: If the judge with the given ID does not exist.
+            httpx.HTTPError: If the request fails.
         """
         resp = self.httpx.get(f"/judges/{judge_id}/versions")
         resp.raise_for_status()
@@ -149,11 +172,16 @@ class JudgesClient:
         
         Args:
             judge (judge_resource.Judge): The judge to render the prompt for.
-            completion_request (Dict[str, Any]): The completion request parameters.
-            completion_response (chat_completion.ChatCompletion): The completion response.
+            completion_request (Dict[str, Any]): The completion request parameters that would be sent to the LLM.
+            completion_response (chat_completion.ChatCompletion): The completion response from the LLM.
 
         Returns:
-            str: The rendered prompt.
+            str: The rendered prompt that would be sent to the Judge.
+
+        Raises:
+            ResourceNotFoundError: If the judge with the given ID does not exist.
+            httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out based on evaluation_timeout config.
         """
         payload = self._prepare_judge_evaluation_payload(judge, completion_request, completion_response)
         resp = self.httpx.post(
@@ -195,6 +223,27 @@ class JudgesClient:
         completion_request: Dict[str, Any],
         completion_response: chat_completion.ChatCompletion,
     ) -> JudgeEvaluation:
+        """Evaluate an LLM response using a specific judge.
+
+        This method sends the completion request and response to the judge for evaluation.
+        The judge will assess the response based on its rubric and return a structured evaluation.
+
+        Args:
+            judge (judge_resource.Judge): The judge to use for evaluation.
+            completion_request (Dict[str, Any]): The original completion request parameters that were sent to the LLM.
+            completion_response (chat_completion.ChatCompletion): The completion response from the LLM to evaluate.
+
+        Returns:
+            JudgeEvaluation: The evaluation results, including:
+                - score: The numerical score assigned by the judge
+                - reasoning: The judge's explanation for the score
+                - metadata: Additional evaluation metadata
+
+        Raises:
+            ResourceNotFoundError: If the judge with the given ID does not exist.
+            httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out based on evaluation_timeout config.
+        """
         payload = self._prepare_judge_evaluation_payload(judge, completion_request, completion_response)
         resp = self.httpx.post(
             f"/judges/{judge.id}:evaluate",
@@ -210,6 +259,27 @@ class JudgesClient:
         completion_request: Dict[str, Any],
         completion_response: chat_completion.ChatCompletion,
     ) -> JudgeEvaluation:
+        """Evaluate an LLM response using a judge specification directly.
+
+        Similar to evaluate(), but instead of using a saved judge, this method accepts a judge
+        specification directly. This is useful for testing new judge specifications before
+        creating a permanent judge.
+
+        Args:
+            judge_spec (Dict[str, Any]): The judge specification to use for evaluation.
+            completion_request (Dict[str, Any]): The original completion request parameters that were sent to the LLM.
+            completion_response (chat_completion.ChatCompletion): The completion response from the LLM to evaluate.
+
+        Returns:
+            JudgeEvaluation: The evaluation results, including:
+                - score: The numerical score assigned by the judge
+                - reasoning: The judge's explanation for the score
+                - metadata: Additional evaluation metadata
+
+        Raises:
+            httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out based on evaluation_timeout config.
+        """
         request_payload = utils.get_evaluation_json_payload(completion_request)
         completion_payload = utils.get_evaluation_json_payload(
             self._ensure_cost_response_in_completion(completion_response)

--- a/src/martian_apart_hack_sdk/backend_clients/organization.py
+++ b/src/martian_apart_hack_sdk/backend_clients/organization.py
@@ -30,6 +30,7 @@ class OrganizationClient:
 
         Raises:
             httpx.HTTPError: If the request fails.
+            httpx.TimeoutException: If the request times out.
         """
         resp = self.httpx.get(
             '/credits'

--- a/src/martian_apart_hack_sdk/backend_clients/organization.py
+++ b/src/martian_apart_hack_sdk/backend_clients/organization.py
@@ -1,4 +1,4 @@
-"""Ogranization API client functions."""
+"""Organization API client functions."""
 
 import dataclasses
 
@@ -10,10 +10,27 @@ from martian_apart_hack_sdk.models.OrganizationBalance import OrganizationBalanc
 
 @dataclasses.dataclass(frozen=True)
 class OrganizationClient:
+    """The client for the Martian Organization API. Use the OrganizationClient to access organization-level features.
+
+    Normally, you don't need to create an OrganizationClient directly. Instead, use the MartianClient.organization property to access the OrganizationClient.
+
+    Args:
+        httpx (httpx.Client): The HTTP client to use for the API.
+        config (utils.ClientConfig): The configuration for the API.
+    """
+
     httpx: httpx.Client
     config: utils.ClientConfig
 
-    def get_credit_balance(self):
+    def get_credit_balance(self) -> OrganizationBalance:
+        """Get the current credit balance for the organization.
+
+        Returns:
+            OrganizationBalance: The organization's current credit balance in USD.
+
+        Raises:
+            httpx.HTTPError: If the request fails.
+        """
         resp = self.httpx.get(
             '/credits'
         )

--- a/src/martian_apart_hack_sdk/judge_specs.py
+++ b/src/martian_apart_hack_sdk/judge_specs.py
@@ -99,9 +99,20 @@ class RubricJudgeSpec:
     extract_judgement: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
+        """Convert the judge specification to a dictionary format suitable for API requests.
+
+        This method serializes the specification, removing any None values to ensure
+        only meaningful configuration is sent to the API.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing all non-None attributes of this
+                specification, ready to be sent to the API.
+        """
         result = dataclasses.asdict(self)
         # Filter out None values.
         return {k: v for k, v in result.items() if v is not None}
 
 
+# For backward compatibility and future extensibility, JudgeSpec is an alias for RubricJudgeSpec.
+# If we add other types of judges in the future, this will become a Union type.
 JudgeSpec = RubricJudgeSpec

--- a/src/martian_apart_hack_sdk/models/JudgeEvaluation.py
+++ b/src/martian_apart_hack_sdk/models/JudgeEvaluation.py
@@ -4,6 +4,25 @@ from typing import Optional
 
 @dataclass(frozen=True)
 class JudgeEvaluation:
+    """A dataclass representing the evaluation results from a judge.
+
+    This class encapsulates the results returned when a judge evaluates an LLM response.
+    The evaluation includes a numerical score, a detailed explanation for the score,
+    and the cost of running the evaluation (if available).
+
+    Attributes:
+        score (float): The numerical score assigned by the judge. The valid range and 
+            interpretation of this score depends on the judge's rubric specification.
+            For example, a binary judge might use 0 and 1, while a scale judge might 
+            use 1-5 or 1-10.
+        reason (str): A detailed explanation from the judge about why they assigned 
+            this score. This typically includes references to specific parts of the 
+            response and how they align with or deviate from the rubric criteria.
+        cost (float | None): The cost in USD of running this evaluation, if the
+            system was able to calculate it. This represents the cost of the LLM 
+            calls made by the judge to evaluate the response. May be None if cost
+            information was not available.
+    """
     score: float
     reason: str
     cost: Optional[float] = None

--- a/src/martian_apart_hack_sdk/models/OrganizationBalance.py
+++ b/src/martian_apart_hack_sdk/models/OrganizationBalance.py
@@ -4,4 +4,14 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class OrganizationBalance:
+    """Represents an organization's credit balance information.
+
+    This class provides information about the available credits in an organization's account.
+    Credits are used to pay for API usage and other Martian services.
+
+    Args:
+        credits (decimal.Decimal): The current number of credits available to the organization, in USD.
+        
+            Credits are represented as a decimal to ensure precise accounting.
+    """
     credits: decimal.Decimal

--- a/src/martian_apart_hack_sdk/resources/judge.py
+++ b/src/martian_apart_hack_sdk/resources/judge.py
@@ -1,3 +1,5 @@
+"""Resource models for Martian judges."""
+
 from __future__ import annotations
 
 import dataclasses
@@ -8,7 +10,27 @@ from openai.types.chat import chat_completion, chat_completion_message_param
 
 @dataclasses.dataclass(frozen=True, repr=True, eq=True, order=True)
 class Judge:
-    """Local proxy for a *remote* Judge resource."""
+    """A Judge resource representing a Martian judge configuration.
+
+    This class serves as the primary interface for judge operations in the SDK.
+    Judge instances are returned by JudgeClient methods (`create_judge`, `get`, `list`)
+    and are used as parameters for operations like evaluating completions or training routers.
+
+    Judges should not be created from this class. Instead, use the `JudgeClient` to create and manage judges.
+
+    The Judge is immutable. You can not update it directly from instances of this class.
+    Instead, use the `JudgeClient` to update the judge.
+    Any updates create a new version of the judge with an incremented version number.
+    Previous versions remain accessible through the `JudgeClient.get()` method.
+
+    Attributes:
+        id (str): The judge's identifier.
+        version (int): The judge version number. Increments with each update.
+        description (str): A human-readable description of the judge's purpose.
+        createTime (str): When the judge was created (RFC 3339 format).
+        name (str): The judge's full resource name (format: "organizations/{org}/judges/{judge_id}").
+        judgeSpec (Dict[str, Any]): The judge's configuration, including rubric and evaluation settings.
+    """
 
     id: str = dataclasses.field(init=False)
     version: int
@@ -18,6 +40,11 @@ class Judge:
     judgeSpec: Dict[str, Any]
 
     def __post_init__(self):
+        """Extract the judge ID from the full resource name and set the `id` field.
+        
+        The ID is taken from the last segment of the name path. For example, from
+        "organizations/org-123/judges/my-judge", the ID would be "my-judge".
+        """
         # Set id as the last segment after the last "/"
         _id = self.name.rsplit("/", 1)[-1]
         object.__setattr__(self, "id", _id)

--- a/src/martian_apart_hack_sdk/resources/router.py
+++ b/src/martian_apart_hack_sdk/resources/router.py
@@ -1,3 +1,5 @@
+"""Resource models for Martian routers."""
+
 from __future__ import annotations
 
 import dataclasses
@@ -6,7 +8,31 @@ from typing import Any, Dict
 
 @dataclasses.dataclass(frozen=True, repr=True, eq=True, order=True)
 class Router:
-    """Local proxy for a *remote* Router resource."""
+    """A Router resource representing a Martian router configuration.
+
+    This class serves as the primary interface for router operations in the SDK.
+    Router instances are returned by RouterClient methods (`create_router`, `get`, `list`)
+    and are used as parameters for operations like running the router or creating training jobs.
+
+    Routers should not be created from this class. Instead, use the `RouterClient` to create and manage routers.
+
+    The Router is immutable. You can not update it directly from instances of this class.
+    Instead, use the `RouterClient` to update the router.
+    Any updates create a new version of the router with an incremented version number.
+    Previous versions remain accessible through the `RouterClient.get()` method.
+
+    Attributes:
+        id (str): The router's identifier.
+        version (int): The router version number. Increments with each update.
+        description (str): A human-readable description of the router's purpose.
+        createTime (str): When the router was created (RFC 3339 format).
+        name (str): The router's full resource name (format: "organizations/{org}/routers/{router_id}").
+        routerSpec (Dict[str, Any]): The router's configuration, including points and executors.
+
+    Note:
+        While this class has public attributes, you typically won't create Router instances directly.
+        Instead, you'll receive them from RouterClient methods and use them in other SDK operations.
+    """
 
     id: str = dataclasses.field(init=False)
     version: int
@@ -16,6 +42,11 @@ class Router:
     routerSpec: Dict[str, Any]
 
     def __post_init__(self):
+        """Extract the router ID from the full resource name and set the `id` field.
+        
+        The ID is taken from the last segment of the name path. For example, from
+        "organizations/org-123/routers/my-router", the ID would be "my-router".
+        """
         # Set id as the last segment after the last "/"
         _id = self.name.rsplit("/", 1)[-1]
         object.__setattr__(self, "id", _id) 


### PR DESCRIPTION
Added docstrings to new methods, and improved doc strings throughout.

I did make one *tiny* edit to the code itself:
in `martian_client.py`, i changed `base_url` to `_base_url`, to make it clear that it is not part of the public API.

other change of note:
Also in `martian_client`, i moved the docstrings for `judges` and `routers` out of the methods and into attributes section of the class doc, as this is consistent with Google's documentation style guide. this also puts `organization` into the same public mental space as `routers` and `judges`, even though the internal implementation is a little different.
