### PR TITLE
Update router to use specific version, when running it

### DIFF
--- a/src/martian_apart_hack_sdk/backend_clients/routers.py
+++ b/src/martian_apart_hack_sdk/backend_clients/routers.py
@@ -195,11 +195,9 @@ class RoutersClient:
         extra_body = {
             **render_extra_body_router_constraint(routing_constraint)
         }
-
-        # TODO Use routing version to run
-
+        version_to_use = version if version is not None else router.version
         response = openai_client.chat.completions.create(
-            **completion_request | {"model": router.name},
+            **completion_request | {"model": f"{router.name}/versions/{version_to_use}"},
             extra_body=extra_body,
             timeout=self.config.evaluation_timeout,
         )

--- a/src/martian_apart_hack_sdk/backend_clients/routers.py
+++ b/src/martian_apart_hack_sdk/backend_clients/routers.py
@@ -195,7 +195,13 @@ class RoutersClient:
         extra_body = {
             **render_extra_body_router_constraint(routing_constraint)
         }
-        version_to_use = version if version is not None else router.version
+        if version is not None:
+            version_to_use = version
+        elif router.version is not None:
+            version_to_use = router.version
+        else:
+            version_to_use = "latest"
+
         response = openai_client.chat.completions.create(
             **completion_request | {"model": f"{router.name}/versions/{version_to_use}"},
             extra_body=extra_body,


### PR DESCRIPTION
This change modifies the router model specification to include a version derived from the provided value or the router's default version. Removed outdated TODO and adjusted the `extra_body` for consistency.