### PR TITLE
update README with install and getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ martian-hackathon/          # Root directory for all hackathon work
    EOL
    ```
 
-   (See `martian-sdk-python/.env-template`)
+   (See `martian-sdk-python/.env.template`)
 
 ### Running the Quickstart Guide
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,90 @@
-# martian-sdk-python
-Martian Python SDK to manage judges and routers
+# Martian Python SDK
 
-How to run demo test:
+The Martian Python SDK provides a simple interface to manage judges and routers for LLM evaluation and routing. This SDK allows you to create, update, and manage judges for evaluating LLM responses, as well as routers for directing traffic between different models.
 
-1. Create a .env file (see .env.template for reference)
-1. `uv sync`
-1. `uv run -m demo.main`
+## Quick Start
+
+### Prerequisites
+
+- Python 3.9 or higher
+- Git
+- [uv](https://github.com/astral-sh/uv) - Fast Python package installer and resolver
+
+### Project Setup
+
+We recommend setting up your project with the following structure:
+```
+martian-hackathon/          # Root directory for all hackathon work
+├── .env                    # Environment variables
+├── .venv/                  # Virtual environment (will be created by uv, below)
+├── martian-sdk-python/     # Cloned SDK repository
+└── project/               # Your hackathon project directory
+```
+
+1. Create and enter the hackathon root directory:
+   ```bash
+   mkdir martian-hackathon
+   cd martian-hackathon
+   ```
+
+2. Clone the SDK repository:
+   ```bash
+   git clone https://github.com/withmartian/martian-sdk-python.git
+   ```
+
+3. Create and activate a virtual environment in the hackathon root directory:
+   ```bash
+   uv venv
+   source .venv/bin/activate  # On Unix/macOS
+   # or
+   .venv\Scripts\activate  # On Windows
+   ```
+
+4. Install the SDK in editable mode along with Jupyter:
+   ```bash
+   uv pip install -e martian-sdk-python
+   uv pip install jupyter
+   ```
+
+5. Create your project directory:
+   ```bash
+   mkdir project
+   ```
+
+6. Create a `.env` file in the hackathon root directory with your Martian credentials:
+   ```bash
+   cat > .env << EOL
+   MARTIAN_API_URL=https://withmartian.com/api
+   MARTIAN_API_KEY=your-api-key
+   EOL
+   ```
+
+   (See `martian-sdk-python/.env-template`)
+
+### Running the Quickstart Guide
+
+The SDK includes a Jupyter notebook that demonstrates key features and usage patterns:
+
+1. From your hackathon parent directory, start Jupyter:
+   ```bash
+   jupyter notebook
+   ```
+
+2. In Jupyter, navigate to `../martian-sdk-python/quickstart_guide.ipynb`
+
+The quickstart guide will walk you through:
+- Setting up the Martian client
+- Using the gateway to access various LLM models
+- Creating and using judges
+- Working with routers
+- Training and evaluating models
+
+
+## Running Tests
+
+To run the demo test, from the SDK directory:
+```bash
+cd martian-sdk-python
+uv sync
+uv run -m demo.main
+```

--- a/src/martian_apart_hack_sdk/utils.py
+++ b/src/martian_apart_hack_sdk/utils.py
@@ -3,6 +3,7 @@
 import dataclasses
 import json
 from typing import Dict, Any
+from pathlib import Path
 
 import dotenv
 
@@ -26,7 +27,20 @@ class ClientConfig:
 
 
 def load_config() -> ClientConfig:
+    # Try current directory first
     config = dotenv.dotenv_values()
+    
+    # If not found, try parent directory
+    if not config:
+        parent_env = Path("../.env")
+        if parent_env.exists():
+            config = dotenv.dotenv_values(parent_env)
+    
+    # If still not found, try parent's parent directory
+    if not config:
+        parent_parent_env = Path("../../.env")
+        if parent_parent_env.exists():
+            config = dotenv.dotenv_values(parent_parent_env)
 
     api_url = config.get("MARTIAN_API_URL")
     api_key = config.get("MARTIAN_API_KEY")

--- a/src/martian_apart_hack_sdk/utils.py
+++ b/src/martian_apart_hack_sdk/utils.py
@@ -2,10 +2,11 @@
 
 import dataclasses
 import json
-from typing import Dict, Any
-from pathlib import Path
+import pathlib
+from typing import Any, Dict
 
 import dotenv
+
 
 @dataclasses.dataclass(frozen=True)
 class ClientConfig:
@@ -17,28 +18,26 @@ class ClientConfig:
     @property
     def openai_api_url(self) -> str:
         """Get the OpenAI API URL.
-        
+
         Returns:
             str: The OpenAI API URL constructed from the base API URL
         """
         return f"{self.api_url}/openai/v2"
 
-    
-
 
 def load_config() -> ClientConfig:
     # Try current directory first
     config = dotenv.dotenv_values()
-    
+
     # If not found, try parent directory
     if not config:
-        parent_env = Path("../.env")
+        parent_env = pathlib.Path("../.env")
         if parent_env.exists():
             config = dotenv.dotenv_values(parent_env)
-    
+
     # If still not found, try parent's parent directory
     if not config:
-        parent_parent_env = Path("../../.env")
+        parent_parent_env = pathlib.Path("../../.env")
         if parent_parent_env.exists():
             config = dotenv.dotenv_values(parent_parent_env)
 


### PR DESCRIPTION
Install and Getting Started instructions for the SDK.

One small code change:
- previous iterations of guidance seem to suggest hackathoners put their project code in the repo dir (ew, gross)
- so in the README i suggest hackathoners put their project code in a dir parallel to the SDK repo
- which means that .env needs to be accessible from both directories
- so the quickstart guide has them putting it (along with .venv) in a parent directory
- so i updated utils.py to go find .env in the parent directory 